### PR TITLE
Add VertexArrayObject destroy method

### DIFF
--- a/lib/VertexArrayObject.js
+++ b/lib/VertexArrayObject.js
@@ -223,7 +223,6 @@ VertexArrayObject.prototype.destroy = function()
 	this.indexBuffer = null;
 	this.attributes = null;
 	this.nativeState = null;
-	this.unbind();
 
 	if(this.nativeVao)
 	{

--- a/lib/VertexArrayObject.js
+++ b/lib/VertexArrayObject.js
@@ -212,3 +212,24 @@ VertexArrayObject.prototype.draw = function(type, size, start)
 
 	return this;
 }
+
+/**
+ * Destroy this vao
+ */
+VertexArrayObject.prototype.destroy = function()
+{
+	// lose references
+	this.gl = null;
+	this.indexBuffer = null;
+	this.attributes = null;
+	this.nativeState = null;
+	this.unbind();
+
+	if(this.nativeVao)
+	{
+		this.nativeVaoExtension.deleteVertexArrayOES(this.nativeVao);
+	}
+
+	this.nativeVaoExtension = null;
+	this.nativeVao = null;
+}


### PR DESCRIPTION
Add a method to destroy the VertexArrayObject.

I'm new to working with GL objects directly. Please carefully review this PR.

Reference: pixijs/pixi.js#2459
