### PR TITLE
Added Atom's loophole implementation of new Function

### DIFF
--- a/lib/shader/generateUniformAccessObject.js
+++ b/lib/shader/generateUniformAccessObject.js
@@ -37,10 +37,43 @@ var generateUniformAccessObject = function(gl, uniformData)
     return uniforms;
 }
 
+var EvalFunction = function()
+{
+    try 
+    {
+        // Solution for Atom/Electron to work around 
+        // the V8 restriction on using unsafe-eval code
+        // this solution is taken from the loophole module
+        // created by atom.
+        var vm = require('vm');
+
+        // Similar to Function, but uses the Node's vm
+        // module to run the code, safer to eval
+        return function() {
+            var slice = [].slice;
+            var body, i, j, len, paramList, paramLists, params;
+            paramLists = 2 <= arguments.length ? slice.call(arguments, 0, i = arguments.length - 1) : (i = 0, []), body = arguments[i++];
+            params = [];
+            for (j = 0, len = paramLists.length; j < len; j++) {
+                paramList = paramLists[j];
+                if (typeof paramList === 'string') {
+                      paramList = paramList.split(/\s*,\s*/);
+                }
+                params.push.apply(params, paramList);
+            }
+            return vm.runInThisContext("(function(" + (params.join(', ')) + ") {\n  " + body + "\n})");
+        };
+    }
+    catch(e)
+    {
+        return Function;
+    }
+}();
+
 var generateGetter = function(name)
 {
 	var template = getterTemplate.replace('%%', name);
-	return new Function(template);
+	return new EvalFunction(template);
 }
 
 var generateSetter = function(name, uniform)
@@ -62,7 +95,7 @@ var generateSetter = function(name, uniform)
         template += "\nthis.gl." + setTemplate + ";";
     }
 
-  	return new Function('value', template);
+  	return new EvalFunction('value', template);
 }
 
 var getUniformGroup = function(nameTokens, uniform)


### PR DESCRIPTION
### Overview

This workaround allows Pixi.js to be used within the latest version of [Atom](https://atom.io). Adds support taken from [loophole](https://github.com/atom/loophole) module which provides a safer solution to `new Function`. Specifically, resolves this error:

```
Refused to evaluate a string as JavaScript because 'unsafe-eval' is not 
an allowed source of script in the following Content Security Policy 
directive: "script-src 'self'".
```

**NOTE:** This change needs to be pushed with the **[unsafe-eval](https://github.com/pixijs/pixi.js/pull/2502)** PR on Pixi.js, which removes the inclusion Browserify's builtin `vm` polyfill.
