### PR TITLE
Critical v4 bug

### DIFF
--- a/src/VertexArrayObject.js
+++ b/src/VertexArrayObject.js
@@ -92,12 +92,11 @@ VertexArrayObject.prototype.bind = function()
         {
             this.dirty = false;
             this.activate();
-        } else
+            return;
+        }
+        if (this.indexBuffer)
         {
-            if (this.indexBuffer)
-            {
-                this.indexBuffer.bind();
-            }
+            this.indexBuffer.bind();
         }
     }
     else

--- a/src/VertexArrayObject.js
+++ b/src/VertexArrayObject.js
@@ -92,6 +92,12 @@ VertexArrayObject.prototype.bind = function()
         {
             this.dirty = false;
             this.activate();
+        } else
+        {
+            if (this.indexBuffer)
+            {
+                this.indexBuffer.bind();
+            }
         }
     }
     else

--- a/src/VertexArrayObject.js
+++ b/src/VertexArrayObject.js
@@ -92,7 +92,7 @@ VertexArrayObject.prototype.bind = function()
         {
             this.dirty = false;
             this.activate();
-            return;
+            return this;
         }
         if (this.indexBuffer)
         {
@@ -101,7 +101,6 @@ VertexArrayObject.prototype.bind = function()
     }
     else
     {
-
         this.activate();
     }
 


### PR DESCRIPTION
There are many places in pixi-v4 that use "createIndexBuffer" without doing `vao.unbind()` first. It changes the current vao! Any upload of index buffer changes vao, and if we do it before we actually create or bind our vao, it .

I started to make PR to `pixi.js` main repo, but saw that there are too many places to fix, and there are even some places in my plugins.

The only good solution is to force bind on index buffer in VAO, like we really dont know whether it was changed. I'll make PR against V5 to fix that problem properly.

https://github.com/pixijs/pixi.js/issues/4458