### PR TITLE
Add `array` to uniforms info , and checking with `array`

### DIFF
--- a/src/shader/extractAttributes.js
+++ b/src/shader/extractAttributes.js
@@ -19,12 +19,14 @@ var extractAttributes = function(gl, program)
     for (var i = 0; i < totalAttributes; i++)
     {
         var attribData = gl.getActiveAttrib(program, i);
+        var name = attribData.name.replace(/\[.*?\]/, "");
         var type = mapType(gl, attribData.type);
+        var array = attribData.name.indexOf('[') > 0;
 
-        attributes[attribData.name] = {
+        attributes[name] = {
             type:type,
             size:mapSize(type),
-            location:gl.getAttribLocation(program, attribData.name),
+            location:gl.getAttribLocation(program, name),
             //TODO - make an attribute object
             pointer: pointer
         };

--- a/src/shader/extractAttributes.js
+++ b/src/shader/extractAttributes.js
@@ -24,9 +24,9 @@ var extractAttributes = function(gl, program)
         attributes[attribData.name] = {
             type:type,
             size:mapSize(type),
-            location:gl.getAttribLocation(program, name),
+            location:gl.getAttribLocation(program, attribData.name),
             //TODO - make an attribute object
-            pointer:pointer
+            pointer: pointer
         };
     }
 

--- a/src/shader/extractAttributes.js
+++ b/src/shader/extractAttributes.js
@@ -24,9 +24,10 @@ var extractAttributes = function(gl, program)
         var array = attribData.name.indexOf('[') > 0;
 
         attributes[name] = {
-            type:type,
-            size:mapSize(type),
-            location:gl.getAttribLocation(program, name),
+            type: type,
+            size: mapSize(type),
+            array: array,
+            location: gl.getAttribLocation(program, name),
             //TODO - make an attribute object
             pointer: pointer
         };

--- a/src/shader/extractAttributes.js
+++ b/src/shader/extractAttributes.js
@@ -21,12 +21,12 @@ var extractAttributes = function(gl, program)
         var attribData = gl.getActiveAttrib(program, i);
         var type = mapType(gl, attribData.type);
 
-        attributes[name] = {
-            type: type,
-            size: mapSize(type),
-            location: gl.getAttribLocation(program, name),
+        attributes[attribData.name] = {
+            type:type,
+            size:mapSize(type),
+            location:gl.getAttribLocation(program, name),
             //TODO - make an attribute object
-            pointer: pointer
+            pointer:pointer
         };
     }
 

--- a/src/shader/extractAttributes.js
+++ b/src/shader/extractAttributes.js
@@ -19,14 +19,11 @@ var extractAttributes = function(gl, program)
     for (var i = 0; i < totalAttributes; i++)
     {
         var attribData = gl.getActiveAttrib(program, i);
-        var name = attribData.name.replace(/\[.*?\]/, "");
         var type = mapType(gl, attribData.type);
-        var array = attribData.name.indexOf('[') > 0;
 
         attributes[name] = {
             type: type,
             size: mapSize(type),
-            array: array,
             location: gl.getAttribLocation(program, name),
             //TODO - make an attribute object
             pointer: pointer

--- a/src/shader/extractUniforms.js
+++ b/src/shader/extractUniforms.js
@@ -20,12 +20,14 @@ var extractUniforms = function(gl, program)
     	var uniformData = gl.getActiveUniform(program, i);
     	var name = uniformData.name.replace(/\[.*?\]/, "");
         var type = mapType(gl, uniformData.type );
+        var array = uniformData.name.indexOf('[') > 0;
 
     	uniforms[name] = {
-    		type:type,
-    		size:uniformData.size,
-    		location:gl.getUniformLocation(program, name),
-    		value:defaultValue(type, uniformData.size)
+    		type: type,
+            size: uniformData.size,
+    		array: array,
+    		location: gl.getUniformLocation(program, name),
+    		value: defaultValue(type, uniformData.size)
     	};
     }
 

--- a/src/shader/extractUniforms.js
+++ b/src/shader/extractUniforms.js
@@ -11,27 +11,27 @@ var defaultValue = require('./defaultValue');
  */
 var extractUniforms = function(gl, program)
 {
-	var uniforms = {};
+    var uniforms = {};
 
     var totalUniforms = gl.getProgramParameter(program, gl.ACTIVE_UNIFORMS);
 
     for (var i = 0; i < totalUniforms; i++)
     {
-    	var uniformData = gl.getActiveUniform(program, i);
-    	var name = uniformData.name.replace(/\[.*?\]/, "");
+        var uniformData = gl.getActiveUniform(program, i);
+        var name = uniformData.name.replace(/\[.*?\]/, "");
         var type = mapType(gl, uniformData.type );
         var array = uniformData.name.indexOf('[') > 0;
 
-    	uniforms[name] = {
-    		type: type,
-    		size: uniformData.size,
-    		array: array,
-    		location: gl.getUniformLocation(program, name),
-    		value: defaultValue(type, uniformData.size)
-    	};
+        uniforms[name] = {
+            type: type,
+            size: uniformData.size,
+            array: array,
+            location: gl.getUniformLocation(program, name),
+            value: defaultValue(type, uniformData.size)
+        };
     }
 
-	return uniforms;
+    return uniforms;
 };
 
 module.exports = extractUniforms;

--- a/src/shader/extractUniforms.js
+++ b/src/shader/extractUniforms.js
@@ -20,7 +20,7 @@ var extractUniforms = function(gl, program)
         var uniformData = gl.getActiveUniform(program, i);
         var name = uniformData.name.replace(/\[.*?\]/, "");
         var type = mapType(gl, uniformData.type );
-        var array = uniformData.name.indexOf('[') > 0;
+        var array = name !== uniformData.name;
 
         uniforms[name] = {
             type: type,

--- a/src/shader/extractUniforms.js
+++ b/src/shader/extractUniforms.js
@@ -24,7 +24,7 @@ var extractUniforms = function(gl, program)
 
     	uniforms[name] = {
     		type: type,
-            size: uniformData.size,
+    		size: uniformData.size,
     		array: array,
     		location: gl.getUniformLocation(program, name),
     		value: defaultValue(type, uniformData.size)

--- a/src/shader/generateUniformAccessObject.js
+++ b/src/shader/generateUniformAccessObject.js
@@ -117,5 +117,4 @@ function getUniformGroup(nameTokens, uniform)
     return cur;
 }
 
-
 module.exports = generateUniformAccessObject;

--- a/src/shader/generateUniformAccessObject.js
+++ b/src/shader/generateUniformAccessObject.js
@@ -67,9 +67,7 @@ var GLSL_SINGLE_SETTERS = {
     mat3: function setSingleMat3(gl, location, value) { gl.uniformMatrix3fv(location, false, value); },
     mat4: function setSingleMat4(gl, location, value) { gl.uniformMatrix4fv(location, false, value); },
 
-    sampler2D: function setSingleSampler2D(gl, location, value) {
-        gl.uniform1i(location, Array.isArray(value) ? value[0] : value);
-    },
+    sampler2D: function setSingleSampler2D(gl, location, value) { gl.uniform1i(location, value); },
 };
 
 var GLSL_ARRAY_SETTERS = {
@@ -93,14 +91,14 @@ function generateSetter(name, uniform)
     return function(value) {
         this.data[name].value = value;
         var location = this.data[name].location;
-        if (uniform.size === 1)
-        {
-            GLSL_SINGLE_SETTERS[uniform.type](this.gl, location, value);
-        }
-        else
+        if (uniform.array)
         {
             // glslSetArray(gl, location, type, value) {
             GLSL_ARRAY_SETTERS[uniform.type](this.gl, location, value);
+        }
+        else
+        {
+            GLSL_SINGLE_SETTERS[uniform.type](this.gl, location, value);
         }
     };
 }

--- a/src/shader/generateUniformAccessObject.js
+++ b/src/shader/generateUniformAccessObject.js
@@ -67,7 +67,9 @@ var GLSL_SINGLE_SETTERS = {
     mat3: function setSingleMat3(gl, location, value) { gl.uniformMatrix3fv(location, false, value); },
     mat4: function setSingleMat4(gl, location, value) { gl.uniformMatrix4fv(location, false, value); },
 
-    sampler2D: function setSingleSampler2D(gl, location, value) { gl.uniform1i(location, value); },
+    sampler2D: function setSingleSampler2D(gl, location, value) {
+        gl.uniform1i(location, Array.isArray(value) ? value[0] : value);
+    },
 };
 
 var GLSL_ARRAY_SETTERS = {


### PR DESCRIPTION
Fix https://github.com/pixijs/pixi.js/issues/4647

In current version , use `GLSL_SINGLE_SETTERS` or `GLSL_ARRAY_SETTERS` is depend on `uniforms.size`.

it's not correct on some Android.

So , add a  flag `uniforms.array` to instead of  `uniforms.size` for checking.