### PR TITLE
Check if texture exists before calling destroy

### DIFF
--- a/src/GLFramebuffer.js
+++ b/src/GLFramebuffer.js
@@ -160,7 +160,7 @@ Framebuffer.prototype.destroy = function()
     var gl = this.gl;
 
     //TODO
-    if(this.texture)
+    if(this.texture && gl.isTexture(this.texture.texture))
     {
         this.texture.destroy();
     }


### PR DESCRIPTION
There is an issue in pixijs project 
[4692](https://github.com/pixijs/pixi.js/issues/4692)
Destroy method in GLTexture is called twice 
In **TextureManager** in `destroyTexture` method - first time it is called when texture is destroyed ` glTextures[uid].destroy()` and second time when **FrameBuffer** in render target is destroyed `glRenderTargets[uid].destroy();`

So I wanted to suggest checking `isTexture` before calling `texture.destroy()` in  **FrameBuffer** - it will return false if texture was already deleted.